### PR TITLE
Add documentation for new Gutenberg filter `editor.PostFeaturedImage`

### DIFF
--- a/filter-admin-post-thumbnail-html.md
+++ b/filter-admin-post-thumbnail-html.md
@@ -20,4 +20,47 @@ Please [open a new issue](https://github.com/danielbachhuber/gutenberg-migration
 
 ## Gutenberg Equivalent
 
-There are no Gutenberg equivalents for this filter.
+[PostFeaturedImage](https://github.com/WordPress/gutenberg/tree/master/editor/components/post-featured-image) is a React component used to render the Post Featured Image selection tool.
+It includes a wp.hooks filter `editor.PostFeaturedImage` that enables developers to replace or extend it.
+
+## Examples
+Replace the contents of the panel:
+
+```js
+wp.hooks.addFilter( 
+	'editor.PostFeaturedImage', 
+	'myplugin/myhook', 
+	function() { 
+		return function() { 
+			return wp.element.createElement( 
+				'div', 
+				{}, 
+				'The replacement contents or components.' 
+			); 
+		} 
+	} 
+);
+```
+
+Prepend/Append to the panel contents:
+```js
+wp.hooks.addFilter( 
+	'editor.PostFeaturedImage', 
+	'myplugin/myhook', 
+	function( original ) { 
+		return function() { 
+			return (
+				wp.element.createElement( 
+					'div', 
+					{ key: 'outer' + Math.random() }, 
+					[
+						'Prepend above',
+						_.extend( original( {} ), { key: 'my-key' } ),
+						'Append below' 
+					]
+				)
+			);
+		} 
+	} 
+);
+```


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/6940