### PR TITLE
Add MyPluginPostStatusInfo example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Action / Filter | Still Exists? | Gutenberg Equivalent? | Learn More
 `edit_form_after_title` | No | None | [Edit Form Actions](action-edit-form.md)
 `edit_form_before_permalink` | No | None | [Edit Form Actions](action-edit-form.md)
 `edit_form_after_editor` | No | None | [Edit Form Actions](action-edit-form.md)
-`enter_title_here` | Yes | N/A | 
-`write_your_story` | Yes | N/A | 
+`enter_title_here` | Yes | N/A |
+`write_your_story` | Yes | N/A |
 `post_updated_messages` | No | No | [Post Updated Messages Filter](filter-post-updated-messages.md)
 `media_buttons` | No | Block Inserter | [Media Buttons](action-media-buttons.md)
-`post_submitbox_minor_actions` | No | None | [Post Submitbox Actions](action-post-submitbox.md)
-`post_submitbox_misc_actions` | No | None | [Post Submitbox Actions](action-post-submitbox.md)
-`post_submitbox_start` | No | None | [Post Submitbox Actions](action-post-submitbox.md)
+`post_submitbox_minor_actions` | No | `PluginPostStatusInfo` | [Post Submitbox Actions](action-post-submitbox.md)
+`post_submitbox_misc_actions` | No | `PluginPostStatusInfo` | [Post Submitbox Actions](action-post-submitbox.md)
+`post_submitbox_start` | No | `PluginPostStatusInfo` | [Post Submitbox Actions](action-post-submitbox.md)
 `default_page_template_title` | Yes | N/A |
 `page_attributes_dropdown_pages_args` | No | None | [Dropdown Pages Args Filters](filter-dropdown-pages-args.md)
 `quick_edit_dropdown_pages_args` | No | None | [Dropdown Pages Args Filters](filter-dropdown-pages-args.md)

--- a/action-post-submitbox.md
+++ b/action-post-submitbox.md
@@ -24,6 +24,8 @@ Please [open a new issue](https://github.com/danielbachhuber/gutenberg-migration
 
 The Post Status Info panel can be extended by the JS Plugins API. You can register a component which fills the `PluginPostStatusInfo` Slot with custom content. The slot is located right before the `Move to Trash` button.
 
+<img width="313" alt="pluginpoststatusinfo" src="https://user-images.githubusercontent.com/695201/45586177-86534280-b8f2-11e8-8e57-651bf524a55e.png">
+
 ## Example
 ```js
 const { PluginPostStatusInfo } = wp.editPost;
@@ -41,5 +43,3 @@ registerPlugin( 'my-plugin-post-status-info', {
 	render: MyPluginPostStatusInfo,
 } );
 ```
-
-<img width="313" alt="pluginpoststatusinfo" src="https://user-images.githubusercontent.com/695201/45586177-86534280-b8f2-11e8-8e57-651bf524a55e.png">

--- a/action-post-submitbox.md
+++ b/action-post-submitbox.md
@@ -22,4 +22,22 @@ Please [open a new issue](https://github.com/danielbachhuber/gutenberg-migration
 
 ## Gutenberg Equivalent
 
-There are no Gutenberg equivalents for these actions.
+The Post Status Info panel can be extended by the JS Plugins API. You can register a component which fills the `PluginPostStatusInfo` Slot with custom content. The slot is located right before the `Move to Trash` button.
+
+## Example
+```js
+const { PluginPostStatusInfo } = wp.editPost;
+const { registerPlugin } = wp.plugins;
+
+const MyPluginPostStatusInfo = () => (
+	<PluginPostStatusInfo
+		className="my-plugin-post-status-info"
+	>
+		My post status info
+	</PluginPostStatusInfo>
+);
+
+registerPlugin( 'my-plugin-post-status-info', {
+	render: MyPluginPostStatusInfo,
+} );
+```

--- a/action-post-submitbox.md
+++ b/action-post-submitbox.md
@@ -41,3 +41,5 @@ registerPlugin( 'my-plugin-post-status-info', {
 	render: MyPluginPostStatusInfo,
 } );
 ```
+
+<img width="313" alt="pluginpoststatusinfo" src="https://user-images.githubusercontent.com/695201/45586177-86534280-b8f2-11e8-8e57-651bf524a55e.png">


### PR DESCRIPTION
Adds an example for `MyPluginPostStatusInfo` to replace post submitbox actions.
Fixes #13 

Should we add ES5 or ES6/JSX examples or both?